### PR TITLE
Fix: Error when setting bounce flag in certain conditions

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -176,13 +176,18 @@ action:
         - trigger_by_nomotion
     sequence:
     - delay: !input off_delay
-    - service: input_boolean.turn_on
-      data: {}
-      target:
-        entity_id: !input debounce_boolean
-    - service: light.turn_off
-      target:
+    - if:
+      - condition: state
         entity_id: !input light_device
+        state: 'on'
+      then:
+      - service: input_boolean.turn_on
+        data: {}
+        target:
+          entity_id: !input debounce_boolean
+      - service: light.turn_off
+        target:
+          entity_id: !input light_device
 
   #
   # Motion during the day, and for no_window rooms


### PR DESCRIPTION
When light is already off, the no-motion try to turn it off again, and this lock the debounce and gobble the next legit action
Fix: #6