### PR TITLE
Fix: Queue requests instead of restart

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -76,7 +76,7 @@ blueprint:
         entity:
           domain: input_boolean
 
-mode: restart
+mode: queued
 max_exceeded: silent
 
 variables:


### PR DESCRIPTION
Use queueing mode because restart can cause issues on debounce and multiple motion sensors