### PR TITLE
Fix: Turn off timer when manual light off

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -206,6 +206,22 @@ action:
       data:
         brightness_pct: "{{ night_brightness}}"
 
+  # #
+  # # Light off
+  # # -> Turn off the manual timer, light has been manually shutoff
+  - conditions:
+    - condition: state
+      entity_id: !input light_device
+      state: 'off'
+    - condition: trigger
+      id:
+        - trigger_by_light
+    sequence:
+    - service: timer.stop
+      data: {}
+      target:
+        entity_id: !input manual_timer
+
   #
   # No motion
   # -> Turn off the light


### PR DESCRIPTION
Need to stop timer and don't use it for light management when manual off was done
Ref: #3