### PR TITLE
Fix: Wrong syntax on light turn_on brightness

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -179,8 +179,8 @@ action:
       - service: light.turn_on
         target:
           entity_id: !input light_device
-          data:
-            brightness_pct: "{{ day_brightness }}"
+        data:
+          brightness_pct: "{{ day_brightness }}"
 
   # #
   # # Light on (after sunset, before sunrise == Night)


### PR DESCRIPTION
Typo tab on service call