### PR TITLE
Fix: Don't set debounce if already set

### DIFF
--- a/light_control.yaml
+++ b/light_control.yaml
@@ -137,6 +137,9 @@ action:
       after: sunrise
     - condition: template
       value_template: "{{ not is_window }}"
+    - condition: state
+      entity_id: !input debounce_boolean
+      state: 'off'
     sequence:
     - service: input_boolean.turn_on
       data: {}
@@ -166,6 +169,9 @@ action:
       after: '08:00:00'
     - condition: template
       value_template: "{{ not is_bedroom }}"
+    - condition: state
+      entity_id: !input debounce_boolean
+      state: 'off'
     sequence:
     - service: input_boolean.turn_on
       data: {}
@@ -197,6 +203,9 @@ action:
       before: '08:00:00'
     - condition: template
       value_template: "{{ not is_bedroom }}"
+    - condition: state
+      entity_id: !input debounce_boolean
+      state: 'off'
     sequence:
     - service: input_boolean.turn_on
       data: {}


### PR DESCRIPTION
In case of already debounce set, don't activate the light, because it means there is already an event running on light !

Ref: #26